### PR TITLE
build(deps): Bump spring boot to 3.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.6</version>
     <relativePath />
   </parent>
   <groupId>com.bracso.test</groupId>


### PR DESCRIPTION
This pull request updates the Spring Boot version in the `pom.xml` file to ensure compatibility with the latest features and bug fixes.

Dependency update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8): Updated the Spring Boot parent version from `3.4.4` to `3.4.6`.